### PR TITLE
Make coordinator more resilient

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ ESCROW_NPUB=npub1hcsc4r3xc9ygnefp4eqyan9r46tjvd3w0dxk2hgydc9k6m5xd3jq2hkjqp
 
 # Mint URL
 MINT_URL=http://0.0.0.0:3338
-#MINT_URL=https://mint.minibits.cash/Bitcoin
+# MINT_URL=https://mint.minibits.cash/Bitcoin
 
 # Nostr relays (comma separated)
 NOSTR_RELAYS="ws://localhost:4736"

--- a/common/src/nostr/mod.rs
+++ b/common/src/nostr/mod.rs
@@ -141,6 +141,10 @@ impl NostrClient {
             .await?;
         Ok(())
     }
+
+    pub fn keys(&self) -> Keys {
+        self.keys.clone()
+    }
 }
 
 async fn init_subscription(

--- a/common/src/nostr/mod.rs
+++ b/common/src/nostr/mod.rs
@@ -141,10 +141,6 @@ impl NostrClient {
             .await?;
         Ok(())
     }
-
-    pub fn keys(&self) -> Keys {
-        self.keys.clone()
-    }
 }
 
 async fn init_subscription(

--- a/coordinator/src/escrow_coordinator/mod.rs
+++ b/coordinator/src/escrow_coordinator/mod.rs
@@ -136,4 +136,15 @@ impl EscrowCoordinator {
         let trade_hash: [u8; 32] = hasher.finalize().into();
         Ok((trade_hash, contract))
     }
+
+    pub async fn restart_coordinator(
+        mut self,
+        keys: Keys,
+        relays: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        self.nostr_client.client.shutdown().await?;
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        self.nostr_client = NostrClient::new(keys, relays).await?;
+        Ok(self)
+    }
 }

--- a/coordinator/src/escrow_coordinator/mod.rs
+++ b/coordinator/src/escrow_coordinator/mod.rs
@@ -137,7 +137,7 @@ impl EscrowCoordinator {
         Ok((trade_hash, contract))
     }
 
-    pub async fn restart_coordinator(
+    pub async fn restart_nostr_client(
         mut self,
         keys: Keys,
         relays: Vec<String>,

--- a/coordinator/src/escrow_coordinator/mod.rs
+++ b/coordinator/src/escrow_coordinator/mod.rs
@@ -142,9 +142,11 @@ impl EscrowCoordinator {
         keys: Keys,
         relays: Vec<String>,
     ) -> anyhow::Result<Self> {
+        warn!("Restarting nostr client...");
         self.nostr_client.client.shutdown().await?;
-        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
         self.nostr_client = NostrClient::new(keys, relays).await?;
+        info!("Nostr client restarted!");
         Ok(self)
     }
 }

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -28,12 +28,5 @@ async fn main() -> anyhow::Result<()> {
         nostr_client.public_key().to_bech32()?
     );
     info!("Starting service and waiting for trades...");
-    let mut coordinator = EscrowCoordinator::new(nostr_client)?;
-    while let Err(err) = coordinator.run().await {
-        error!("Coordinator loop exited with error: {:?}", err);
-        coordinator = coordinator
-            .restart_nostr_client(keys.clone(), relays.clone())
-            .await?;
-    }
-    Ok(())
+    return EscrowCoordinator::new(nostr_client)?.run().await;
 }

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     while let Err(err) = coordinator.run().await {
         error!("Coordinator loop exited with error: {:?}", err);
         coordinator = coordinator
-            .restart_coordinator(keys.clone(), relays.clone())
+            .restart_nostr_client(keys.clone(), relays.clone())
             .await?;
     }
     Ok(())

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -28,5 +28,6 @@ async fn main() -> anyhow::Result<()> {
         nostr_client.public_key().to_bech32()?
     );
     info!("Starting service and waiting for trades...");
-    return EscrowCoordinator::new(nostr_client)?.run().await;
+    loop {}
+    // return EscrowCoordinator::new(nostr_client)?.run().await;
 }


### PR DESCRIPTION
Addresses https://github.com/f321x/cashu-escrow-kit/issues/11
If the coordinator crashes for any reason it now tries to close the old nostr client, wait 60 seconds and then creates a new nostr client (new connections & subscriptions) without losing the pending and ongoing contracts. 
While this could maybe designed with more advanced timeout mechanisms this should be able to catch most problems (that happen rarely anyways) without adding too much complexity.