### PR TITLE
change link to bucket fork repo in readme

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ SELLER_NPUB=npub1pjnvp4kwud0r80kk23h726tn8ewfqmd4y5m9g2rggs0xrdzrgexq0hv5gr
 # Escrow Coordinator
 ESCROW_NSEC=nsec1z62pah093gfj7wzjssc24x3nczmjgy778pxwale7hwesemmzln0qc4dhhu
 ESCROW_NPUB=npub1hcsc4r3xc9ygnefp4eqyan9r46tjvd3w0dxk2hgydc9k6m5xd3jq2hkjqp
+ADMIN_NPUB=npub...
 
 # Mint URL
 MINT_URL=http://0.0.0.0:3338

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The client could be distributed as wasm library and rust crate. There could also
 ## Testing
 The current `NostrClient` code only uses an in memory local test relay, which must be started before testing.
 
-By now we use the relay at `git@github.com:rodant/bucket.git`. To start the relay locally:
+By now we use the relay at `https://github.com/rodant/bucket`. To start the relay locally:
 1. Checkout the master branch from the repo above.
 2. Run `yarn`, only needed the first time.
 2. Start the relay with `yarn start`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The client could be distributed as wasm library and rust crate. There could also
 ## Testing
 The current `NostrClient` code only uses an in memory local test relay, which must be started before testing.
 
-By now we use the relay at `https://github.com/rodant/bucket`. To start the relay locally:
+By now we use the relay at `https://github.com/coracle-social/bucket`. To start the relay locally:
 1. Checkout the master branch from the repo above.
 2. Run `yarn`, only needed the first time.
 2. Start the relay with `yarn start`.


### PR DESCRIPTION
Changes the link to the bucket fork in the README.md to http format as the current one gives permission errors when trying to clone it.